### PR TITLE
include container labels in the log message

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ var toEmit = function toEmit(data, container) {
     id: container.Id,
     type: data.status,
     image: container.Image,
+    labels: container.Config.Labels,
     name: name,
     host: data.from,
     execute: exec


### PR DESCRIPTION
This change include docker labels in the log message. This is useful for us with ECS as ECS includes things like the service and task that the container corresponds to as labels on the container.

Thanks

Tom
