### PR TITLE
Updating never-ending-stream to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "main": "index.js",
   "dependencies": {
     "dockerode": "^2.2.2",
-    "never-ending-stream": "^1.1.2",
+    "never-ending-stream": "^2.0.0",
     "through2": "^2.0.0"
   },
   "repository": {


### PR DESCRIPTION
The old version of never-ending-stream uses through2 v0.6.5, which caused more memory leaks.
Still an issue somewhere in node 8.

Tested using an updated version of https://github.com/rapid7/docker-logentries